### PR TITLE
Patch for Privacy Preserving Learning

### DIFF
--- a/test/unit_test/weights_test.cc
+++ b/test/unit_test/weights_test.cc
@@ -26,3 +26,28 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(test_default_function_weight_initialization_stride
   }
 }
 
+BOOST_AUTO_TEST_CASE_TEMPLATE(test_feature_is_activated, T, weight_types) // unit test to check if number of bits equal to the threshold in bitset set to 1 for a feature returns true
+{
+  T w(LENGTH, STRIDE_SHIFT);
+  int feature_index=0;
+  int threshold=10;
+  for(int tag_hash=0;tag_hash<threshold;tag_hash++) // function to set the bits in bitset to 1 equal to the threshold 
+  {
+    w.set_tag(tag_hash);
+    w.turn_on_bit(feature_index); 
+  }
+  BOOST_CHECK_EQUAL(w.is_activated(feature_index),true); 
+}
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(test_feature_not_activated, T, weight_types) // unit test to check if number of bits less than the threshold in bitset set to 1 for a feature returns false
+{
+  T w(LENGTH, STRIDE_SHIFT);
+  int feature_index=0;
+  int threshold=10;
+  for(int tag_hash=0;tag_hash<(threshold-1);tag_hash++) // function to set the bits in bitset to 1 equal to the (threshold-1)
+  {
+    w.set_tag(tag_hash);
+    w.turn_on_bit(feature_index);
+  }
+  BOOST_CHECK_EQUAL(w.is_activated(feature_index),false); 
+}

--- a/vowpalwabbit/array_parameters.h
+++ b/vowpalwabbit/array_parameters.h
@@ -87,6 +87,15 @@ private:
     return iter->second;
   }
 
+  std::unordered_map<uint64_t, std::bitset<32>> _feature_bit_vector; // define the 32-bitset for each feature
+  struct _tag_hash_info // define struct to store the information of the tag hash
+  {
+    uint64_t tag_hash;
+    bool is_set=false;
+  };
+  
+  _tag_hash_info _tag_info;
+
 public:
   typedef sparse_iterator<weight> iterator;
   typedef sparse_iterator<const weight> const_iterator;
@@ -108,32 +117,23 @@ public:
 
   bool not_null() { return (_weight_mask > 0 && !_map.empty()); }
 
-  std::unordered_map<uint64_t, std::bitset<32>> feature_bit_vector_sparse; // define the 32-bitset for each feature
-  struct tag_hash_info_sparse // define struct to store the information of the tag hash
-  {
-    uint64_t tag_hash;
-    bool is_set=false;
-  };
-
-  tag_hash_info_sparse tag_info_sparse;
-
   void set_tag(uint64_t tag_hash) // function to store the tag hash for a feature and set it to true
   {
-    tag_info_sparse.tag_hash=tag_hash;
-    tag_info_sparse.is_set=true;
+    _tag_info.tag_hash=tag_hash;
+    _tag_info.is_set=true;
   }
   
   void turn_on_bit(uint64_t feature_index) // function to lookup a bit for a feature in the 32-bitset using the 5-bit tag hash and set it to 1.
   {
-    if(feature_index % stride() == 0 && tag_info_sparse.is_set) 
+    if(_tag_info.is_set) 
     {
-      feature_bit_vector_sparse[feature_index][tag_info_sparse.tag_hash]=1;
+      _feature_bit_vector[feature_index][_tag_info.tag_hash]=1;
     }
   }
 
-  void unset_tag(){ tag_info_sparse.is_set=false;} // function to set the tag to false after an example is trained on
+  void unset_tag(){ _tag_info.is_set=false;} // function to set the tag to false after an example is trained on
 
-  bool is_activated(size_t index){return feature_bit_vector_sparse[index].count()>=10;} // function to check if the number of bits set to 1 are greater than a threshold for a feature 
+  bool is_activated(size_t index){return _feature_bit_vector[index].count()>=10;} // function to check if the number of bits set to 1 are greater than a threshold for a feature 
 
   sparse_parameters(const sparse_parameters& other) = delete;
   sparse_parameters& operator=(const sparse_parameters& other) = delete;

--- a/vowpalwabbit/array_parameters.h
+++ b/vowpalwabbit/array_parameters.h
@@ -125,7 +125,7 @@ public:
   {
     if(_tag_info.is_set) 
     {
-      _feature_bit_vector[feature_index][_tag_info.tag_hash]=1;
+      _feature_bit_vector[feature_index & _weight_mask][_tag_info.tag_hash]=1;
     }
   }
 

--- a/vowpalwabbit/array_parameters.h
+++ b/vowpalwabbit/array_parameters.h
@@ -64,6 +64,11 @@ public:
 class sparse_parameters
 {
 private:
+  struct tag_hash_info // define struct to store the information of the tag hash
+  {
+    uint64_t tag_hash;
+    bool is_set=false;
+  };
   // This must be mutable because the const operator[] must be able to intialize default weights to return.
   mutable weight_map _map;
   uint64_t _weight_mask;  // (stride*(1 << num_bits) -1)
@@ -71,6 +76,8 @@ private:
   bool _seeded;  // whether the instance is sharing model state with others
   bool _delete;
   std::function<void(weight*, uint64_t)> _default_func;
+  std::unordered_map<uint64_t, std::bitset<32>> _feature_bit_vector; // define the 32-bitset for each feature
+  tag_hash_info _tag_info;
 
   // It is marked const so it can be used from both const and non const operator[]
   // The map itself is mutable to facilitate this
@@ -86,15 +93,6 @@ private:
     }
     return iter->second;
   }
-
-  std::unordered_map<uint64_t, std::bitset<32>> _feature_bit_vector; // define the 32-bitset for each feature
-  struct _tag_hash_info // define struct to store the information of the tag hash
-  {
-    uint64_t tag_hash;
-    bool is_set=false;
-  };
-  
-  _tag_hash_info _tag_info;
 
 public:
   typedef sparse_iterator<weight> iterator;
@@ -133,7 +131,7 @@ public:
 
   void unset_tag(){ _tag_info.is_set=false;} // function to set the tag to false after an example is trained on
 
-  bool is_activated(size_t index){return _feature_bit_vector[index].count()>=10;} // function to check if the number of bits set to 1 are greater than a threshold for a feature 
+  bool is_activated(uint64_t index){return _feature_bit_vector[index].count()>=10;} // function to check if the number of bits set to 1 are greater than a threshold for a feature 
 
   sparse_parameters(const sparse_parameters& other) = delete;
   sparse_parameters& operator=(const sparse_parameters& other) = delete;

--- a/vowpalwabbit/array_parameters_dense.h
+++ b/vowpalwabbit/array_parameters_dense.h
@@ -106,7 +106,7 @@ public:
   {
     if(_tag_info.is_set)
     {
-      _feature_bit_vector[feature_index][_tag_info.tag_hash]=1;
+      _feature_bit_vector[feature_index & _weight_mask][_tag_info.tag_hash]=1;
     }
   }
 

--- a/vowpalwabbit/array_parameters_dense.h
+++ b/vowpalwabbit/array_parameters_dense.h
@@ -49,19 +49,17 @@ public:
 class dense_parameters
 {
 private:
-  weight* _begin;
-  uint64_t _weight_mask;  // (stride*(1 << num_bits) -1)
-  uint32_t _stride_shift;
-  bool _seeded;  // whether the instance is sharing model state with others
-
-  std::unordered_map<uint64_t, std::bitset<32>> _feature_bit_vector; // define the 32-bitset for each feature
-  struct _tag_hash_info // define struct to store the information of the tag hash
+  struct tag_hash_info // define struct to store the information of the tag hash
   {
     uint64_t tag_hash;
     bool is_set=false;
   };
-
-  _tag_hash_info _tag_info;
+  weight* _begin;
+  uint64_t _weight_mask;  // (stride*(1 << num_bits) -1)
+  uint32_t _stride_shift;
+  bool _seeded;  // whether the instance is sharing model state with others
+  std::unordered_map<uint64_t, std::bitset<32>> _feature_bit_vector; // define the 32-bitset for each feature
+  tag_hash_info _tag_info;
 
 public:
   typedef dense_iterator<weight> iterator;
@@ -114,7 +112,7 @@ public:
 
   void unset_tag(){ _tag_info.is_set=false;} // function to set the tag to false after an example is trained on
 
-  bool is_activated(size_t index){return _feature_bit_vector[index].count()>=10;} // function to check if the number of bits set to 1 are greater than a threshold for a feature
+  bool is_activated(uint64_t index){return _feature_bit_vector[index].count()>=10;} // function to check if the number of bits set to 1 are greater than a threshold for a feature
 
   void shallow_copy(const dense_parameters& input)
   {

--- a/vowpalwabbit/array_parameters_dense.h
+++ b/vowpalwabbit/array_parameters_dense.h
@@ -10,6 +10,8 @@
 #endif
 
 #include "memory.h"
+#include <bitset>
+#include <unordered_map>
 
 typedef float weight;
 
@@ -86,6 +88,32 @@ public:
 
   inline const weight& operator[](size_t i) const { return _begin[i & _weight_mask]; }
   inline weight& operator[](size_t i) { return _begin[i & _weight_mask]; }
+
+  // Definitions for aggregated learning
+  std::unordered_map<uint64_t, std::bitset<32>> feature_bit_vector;
+  struct tag_hash_info
+  {
+    uint64_t tag_hash;
+    bool is_set=false;
+  };
+
+  void set_tag(uint64_t tag_hash)
+  {
+      tag_hash_info tag_info;
+      tag_info.tag_hash=tag_hash;
+      tag_info.is_set=true;
+  }
+  
+  void turn_on_bit(uint64_t feature_index) // how does offset work in dense?
+  {
+    tag_hash_info tag_info;
+    if(feature_index % stride() == 0 && tag_info.is_set) // how does offset work in dense?
+    {
+      feature_bit_vector[feature_index][tag_info.tag_hash]=1;
+    }
+  }
+
+  bool is_activated(size_t index){return feature_bit_vector[index].count()>=10;}
 
   void shallow_copy(const dense_parameters& input)
   {

--- a/vowpalwabbit/cb_explore_adf_rnd.cc
+++ b/vowpalwabbit/cb_explore_adf_rnd.cc
@@ -154,10 +154,10 @@ inline void vec_add_with_norm(std::pair<float, float>& p, float fx, float fw)
 
 float cb_explore_adf_rnd::get_initial_prediction(example* ec)
 {
-  LazyGaussian w;
+  const LazyGaussian w;
 
   std::pair<float, float> dotwithnorm(0.f, 0.f);
-  GD::foreach_feature<std::pair<float, float>, float, vec_add_with_norm, LazyGaussian>(
+  GD::foreach_feature<std::pair<float, float>, float, vec_add_with_norm, const LazyGaussian>(
       w, all->ignore_some_linear, all->ignore_linear, all->interactions, all->permutations, *ec, dotwithnorm);
 
   return sqrtinvlambda * dotwithnorm.second / std::sqrt(2.0f * std::max(1e-12f, dotwithnorm.first));

--- a/vowpalwabbit/cb_explore_adf_rnd.cc
+++ b/vowpalwabbit/cb_explore_adf_rnd.cc
@@ -154,7 +154,7 @@ inline void vec_add_with_norm(std::pair<float, float>& p, float fx, float fw)
 
 float cb_explore_adf_rnd::get_initial_prediction(example* ec)
 {
-  const LazyGaussian w;
+  const LazyGaussian w; // defined as a const as its used in a prediction function and helps assist in calling the overloaded foreach_feature()
 
   std::pair<float, float> dotwithnorm(0.f, 0.f);
   GD::foreach_feature<std::pair<float, float>, float, vec_add_with_norm, const LazyGaussian>(

--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -776,7 +776,7 @@ void save_load_regressor(vw& all, io_buf& model_file, bool read, bool text, T& w
     } while (brw > 0);
   else  // write
     for (typename T::iterator v = weights.begin(); v != weights.end(); ++v)
-      if (*v != 0.)
+      if (*v != 0. && weights.is_activated(v.index())) // checks for a non zero weight value and if the number of bits set to 1 for a feature greater than the threshold
       {
         i = v.index() >> weights.stride_shift();
         std::stringstream msg;

--- a/vowpalwabbit/gd.cc
+++ b/vowpalwabbit/gd.cc
@@ -776,7 +776,7 @@ void save_load_regressor(vw& all, io_buf& model_file, bool read, bool text, T& w
     } while (brw > 0);
   else  // write
     for (typename T::iterator v = weights.begin(); v != weights.end(); ++v)
-      if (*v != 0. && weights.is_activated(v.index())) // checks for a non zero weight value and if the number of bits set to 1 for a feature greater than the threshold
+      if (*v != 0.)
       {
         i = v.index() >> weights.stride_shift();
         std::stringstream msg;

--- a/vowpalwabbit/gd.h
+++ b/vowpalwabbit/gd.h
@@ -65,23 +65,37 @@ inline void vec_add_multipredict(multipredict_info<T>& mp, const float fx, uint6
 template <class DataT, class WeightOrIndexT, void (*FuncT)(DataT&, float, WeightOrIndexT)>
 inline void foreach_feature(vw& all, example& ec, DataT& dat)
 {
-  return all.weights.sparse
-      ? foreach_feature<DataT, WeightOrIndexT, FuncT, sparse_parameters>(all.weights.sparse_weights,
-            all.ignore_some_linear, all.ignore_linear, *ec.interactions, all.permutations, ec, dat)
-      : foreach_feature<DataT, WeightOrIndexT, FuncT, dense_parameters>(all.weights.dense_weights,
+  if(all.weights.sparse)
+  {
+    all.weights.sparse_weights.set_tag(hashall(ec.tag.begin(),ec.tag.size(),all.hash_seed)%32);
+    return foreach_feature<DataT, WeightOrIndexT, FuncT, sparse_parameters>(all.weights.sparse_weights,
             all.ignore_some_linear, all.ignore_linear, *ec.interactions, all.permutations, ec, dat);
+  }
+  else
+  {
+    all.weights.dense_weights.set_tag(hashall(ec.tag.begin(),ec.tag.size(),all.hash_seed)%32);
+    return foreach_feature<DataT, WeightOrIndexT, FuncT, dense_parameters>(all.weights.dense_weights,
+            all.ignore_some_linear, all.ignore_linear, *ec.interactions, all.permutations, ec, dat);
+  }
 }
-
 // iterate through one namespace (or its part), callback function FuncT(some_data_R, feature_value_x, feature_weight)
 template <class DataT, class WeightOrIndexT, void (*FuncT)(DataT&, float, WeightOrIndexT)>
 inline void foreach_feature(vw& all, example& ec, DataT& dat, size_t& num_interacted_features)
 {
-  return all.weights.sparse ? foreach_feature<DataT, WeightOrIndexT, FuncT, sparse_parameters>(
+  if(all.weights.sparse)
+  {
+    all.weights.sparse_weights.set_tag(hashall(ec.tag.begin(),ec.tag.size(),all.hash_seed)%32);
+    return foreach_feature<DataT, WeightOrIndexT, FuncT, sparse_parameters>(
                                   all.weights.sparse_weights, all.ignore_some_linear, all.ignore_linear,
-                                  *ec.interactions, all.permutations, ec, dat, num_interacted_features)
-                            : foreach_feature<DataT, WeightOrIndexT, FuncT, dense_parameters>(all.weights.dense_weights,
+                                  *ec.interactions, all.permutations, ec, dat, num_interacted_features);
+  }
+  else
+  {
+    all.weights.dense_weights.set_tag(hashall(ec.tag.begin(),ec.tag.size(),all.hash_seed)%32);
+    return foreach_feature<DataT, WeightOrIndexT, FuncT, dense_parameters>(all.weights.dense_weights,
                                   all.ignore_some_linear, all.ignore_linear, *ec.interactions, all.permutations, ec,
                                   dat, num_interacted_features);
+  }
 }
 
 // iterate through all namespaces and quadratic&cubic features, callback function T(some_data_R, feature_value_x,

--- a/vowpalwabbit/gd.h
+++ b/vowpalwabbit/gd.h
@@ -84,17 +84,19 @@ inline void foreach_feature(vw& all, example& ec, DataT& dat, size_t& num_intera
 {
   if(all.weights.sparse)
   {
-    all.weights.sparse_weights.set_tag(hashall(ec.tag.begin(),ec.tag.size(),all.hash_seed)%32);
-    return foreach_feature<DataT, WeightOrIndexT, FuncT, sparse_parameters>(
+    all.weights.sparse_weights.set_tag(hashall(ec.tag.begin(),ec.tag.size(),all.hash_seed)%32); // find the 5-bit hash of the tag for sparse weights
+    foreach_feature<DataT, WeightOrIndexT, FuncT, sparse_parameters>(
                                   all.weights.sparse_weights, all.ignore_some_linear, all.ignore_linear,
                                   *ec.interactions, all.permutations, ec, dat, num_interacted_features);
+    all.weights.sparse_weights.unset_tag(); // set the tag to false after the example has been trained on
   }
   else
   {
-    all.weights.dense_weights.set_tag(hashall(ec.tag.begin(),ec.tag.size(),all.hash_seed)%32);
-    return foreach_feature<DataT, WeightOrIndexT, FuncT, dense_parameters>(all.weights.dense_weights,
+    all.weights.dense_weights.set_tag(hashall(ec.tag.begin(),ec.tag.size(),all.hash_seed)%32); // find the 5-bit hash of the tag for dense weights
+    foreach_feature<DataT, WeightOrIndexT, FuncT, dense_parameters>(all.weights.dense_weights,
                                   all.ignore_some_linear, all.ignore_linear, *ec.interactions, all.permutations, ec,
                                   dat, num_interacted_features);
+    all.weights.dense_weights.unset_tag(); // set the tag to false after the example has been trained on
   }
 }
 

--- a/vowpalwabbit/gd.h
+++ b/vowpalwabbit/gd.h
@@ -67,15 +67,17 @@ inline void foreach_feature(vw& all, example& ec, DataT& dat)
 {
   if(all.weights.sparse)
   {
-    all.weights.sparse_weights.set_tag(hashall(ec.tag.begin(),ec.tag.size(),all.hash_seed)%32);
-    return foreach_feature<DataT, WeightOrIndexT, FuncT, sparse_parameters>(all.weights.sparse_weights,
+    all.weights.sparse_weights.set_tag(hashall(ec.tag.begin(),ec.tag.size(),all.hash_seed)%32); // find the 5-bit hash of the tag for sparse weights
+    foreach_feature<DataT, WeightOrIndexT, FuncT, sparse_parameters>(all.weights.sparse_weights,
             all.ignore_some_linear, all.ignore_linear, *ec.interactions, all.permutations, ec, dat);
+    all.weights.sparse_weights.unset_tag(); // set the tag to false after the example has been trained on
   }
   else
   {
-    all.weights.dense_weights.set_tag(hashall(ec.tag.begin(),ec.tag.size(),all.hash_seed)%32);
-    return foreach_feature<DataT, WeightOrIndexT, FuncT, dense_parameters>(all.weights.dense_weights,
+    all.weights.dense_weights.set_tag(hashall(ec.tag.begin(),ec.tag.size(),all.hash_seed)%32); // find the 5-bit hash of the tag for dense weights
+    foreach_feature<DataT, WeightOrIndexT, FuncT, dense_parameters>(all.weights.dense_weights,
             all.ignore_some_linear, all.ignore_linear, *ec.interactions, all.permutations, ec, dat);
+    all.weights.dense_weights.unset_tag(); // set the tag to false after the example has been trained on  
   }
 }
 // iterate through one namespace (or its part), callback function FuncT(some_data_R, feature_value_x, feature_weight)

--- a/vowpalwabbit/gd_predict.h
+++ b/vowpalwabbit/gd_predict.h
@@ -19,7 +19,7 @@ void foreach_feature(WeightsT& weights, const features& fs, DataT& dat, uint64_t
 {
   for (const auto& f : fs) 
   { 
-    weights.turn_on_bit(f.index()); // set a bit in the bitset to 1 for the feature
+    weights.turn_on_bit(f.index() + offset); // set a bit in the bitset to 1 for the feature
     FuncT(dat, mult * f.value(), f.index() + offset); 
   }
 }
@@ -30,7 +30,7 @@ inline void foreach_feature(WeightsT& weights, const features& fs, DataT& dat, u
 {
   for (const auto& f : fs)
   {
-    weights.turn_on_bit(f.index()); // set a bit in the bitset to 1 for the feature
+    weights.turn_on_bit(f.index() + offset); // set a bit in the bitset to 1 for the feature
     weight& w = weights[(f.index() + offset)];
     FuncT(dat, mult * f.value(), w);
   }
@@ -51,7 +51,7 @@ inline void foreach_feature(
 {
   for (const auto& f : fs) 
   { 
-    weights.turn_on_bit(f.index()); // set a bit in the bitset to 1 for the feature
+    weights.turn_on_bit(f.index() + offset); // set a bit in the bitset to 1 for the feature
     FuncT(dat, mult * f.value(), weights[(f.index() + offset)]);
   }
 }

--- a/vowpalwabbit/gd_predict.h
+++ b/vowpalwabbit/gd_predict.h
@@ -19,7 +19,7 @@ void foreach_feature(WeightsT& weights, const features& fs, DataT& dat, uint64_t
 {
   for (const auto& f : fs) 
   { 
-    weights.turn_on_bit(f.index());
+    weights.turn_on_bit(f.index()); // set a bit in the bitset to 1 for the feature
     FuncT(dat, mult * f.value(), f.index() + offset); 
   }
 }
@@ -30,7 +30,7 @@ inline void foreach_feature(WeightsT& weights, const features& fs, DataT& dat, u
 {
   for (const auto& f : fs)
   {
-    weights.turn_on_bit(f.index());
+    weights.turn_on_bit(f.index()); // set a bit in the bitset to 1 for the feature
     weight& w = weights[(f.index() + offset)];
     FuncT(dat, mult * f.value(), w);
   }
@@ -41,9 +41,7 @@ template <class DataT, void (*FuncT)(DataT&, float, float), class WeightsT>
 inline void foreach_feature(
     const WeightsT& weights, const features& fs, DataT& dat, uint64_t offset = 0, float mult = 1.)
 {
-  for (const auto& f : fs) { 
-    FuncT(dat, mult * f.value(), weights[(f.index() + offset)]);
-    }
+  for (const auto& f : fs) { FuncT(dat, mult * f.value(), weights[(f.index() + offset)]);}
 }
 
 // iterate through one namespace (or its part), callback function FuncT(some_data_R, feature_value_x, feature_weight)
@@ -51,10 +49,11 @@ template <class DataT, void (*FuncT)(DataT&, float, float), class WeightsT>
 inline void foreach_feature(
     WeightsT& weights, const features& fs, DataT& dat, uint64_t offset = 0, float mult = 1.)
 {
-  for (const auto& f : fs) { 
-    weights.turn_on_bit(f.index());
+  for (const auto& f : fs) 
+  { 
+    weights.turn_on_bit(f.index()); // set a bit in the bitset to 1 for the feature
     FuncT(dat, mult * f.value(), weights[(f.index() + offset)]);
-    }
+  }
 }
 
 template <class DataT>
@@ -99,28 +98,6 @@ inline void foreach_feature(WeightsT& weights, bool ignore_some_linear, std::arr
       interactions, permutations, ec, dat, weights, num_interacted_features);
 }
 
-// template <class DataT, class WeightOrIndexT, void (*FuncT)(DataT&, float, WeightOrIndexT), class WeightsT>
-// inline void foreach_feature(WeightsT& weights, bool ignore_some_linear, std::array<bool, NUM_NAMESPACES>& ignore_linear,
-//     const std::vector<std::vector<namespace_index>>& interactions, bool permutations, example_predict& ec, DataT& dat,
-//     size_t& num_interacted_features, struct tag_info)
-// {
-//   uint64_t offset = ec.ft_offset;
-//   if (ignore_some_linear)
-//     for (example_predict::iterator i = ec.begin(); i != ec.end(); ++i)
-//     {
-//       if (!ignore_linear[i.index()])
-//       {
-//         features& f = *i;
-//         foreach_feature<DataT, FuncT, WeightsT>(weights, f, dat, offset);
-//       }
-//     }
-//   else
-//     for (features& f : ec) foreach_feature<DataT, FuncT, WeightsT>(weights, f, dat, tag_info, offset);
-
-//   generate_interactions<DataT, WeightOrIndexT, FuncT, WeightsT>(
-//       interactions, permutations, ec, dat, weights, num_interacted_features);
-// }
-
 template <class DataT, class WeightOrIndexT, void (*FuncT)(DataT&, float, WeightOrIndexT), class WeightsT>
 inline void foreach_feature(WeightsT& weights, bool ignore_some_linear, std::array<bool, NUM_NAMESPACES>& ignore_linear,
     const std::vector<std::vector<namespace_index>>& interactions, bool permutations, example_predict& ec, DataT& dat)
@@ -129,15 +106,6 @@ inline void foreach_feature(WeightsT& weights, bool ignore_some_linear, std::arr
   foreach_feature<DataT, WeightOrIndexT, FuncT, WeightsT>(
       weights, ignore_some_linear, ignore_linear, interactions, permutations, ec, dat, num_interacted_features_ignored);
 }
-
-// template <class DataT, class WeightOrIndexT, void (*FuncT)(DataT&, float, WeightOrIndexT), class WeightsT>
-// inline void foreach_feature(WeightsT& weights, bool ignore_some_linear, std::array<bool, NUM_NAMESPACES>& ignore_linear,
-//     const std::vector<std::vector<namespace_index>>& interactions, bool permutations, example_predict& ec, DataT& dat, struct tag_info)
-// {
-//   size_t num_interacted_features_ignored = 0;
-//   foreach_feature<DataT, WeightOrIndexT, FuncT, WeightsT>(
-//       weights, ignore_some_linear, ignore_linear, interactions, permutations, ec, dat, num_interacted_features_ignored, tag_info);
-// }
 
 inline void vec_add(float& p, float fx, float fw) { p += fw * fx; }
 

--- a/vowpalwabbit/mwt.cc
+++ b/vowpalwabbit/mwt.cc
@@ -69,7 +69,16 @@ void predict_or_learn(mwt& c, single_learner& base, example& ec)
     c.total++;
     // For each nonzero feature in observed namespaces, check it's value.
     for (unsigned char ns : ec.indices)
-      if (c.namespaces[ns]) GD::foreach_feature<mwt, value_policy>(c.all, ec.feature_space[ns], c);
+    {
+      if (c.all->weights.sparse)
+      {
+        if (c.namespaces[ns]) GD::foreach_feature<mwt, value_policy, sparse_parameters>(c.all->weights.sparse_weights, ec.feature_space[ns], c);
+      }
+      else
+      {
+        if (c.namespaces[ns]) GD::foreach_feature<mwt, value_policy, dense_parameters>(c.all->weights.dense_weights, ec.feature_space[ns], c);
+      }
+    }
     for (uint64_t policy : c.policies)
     {
       c.evals[policy].cost += get_cost_estimate(c.optional_observation.second, c.evals[policy].action);

--- a/vowpalwabbit/search.cc
+++ b/vowpalwabbit/search.cc
@@ -666,7 +666,14 @@ void add_neighbor_features(search_private& priv, multi_ex& ec_seq)
       else  // this is actually a neighbor
       {
         example& other = *ec_seq[n + offset];
-        GD::foreach_feature<search_private, add_new_feature>(priv.all, other.feature_space[ns], priv, me.ft_offset);
+        if(priv.all->weights.sparse)
+        {
+          GD::foreach_feature<search_private, add_new_feature, sparse_parameters>(priv.all->weights.sparse_weights, other.feature_space[ns], priv, me.ft_offset);
+        }
+        else
+        {
+          GD::foreach_feature<search_private, add_new_feature, dense_parameters>(priv.all->weights.dense_weights, other.feature_space[ns], priv, me.ft_offset);
+        }
       }
     }
 


### PR DESCRIPTION
1) Created a 32-bit bitset for each feature. [Dense and Sparse parameters]
2) Computed the 5-bit hash of the tag of the example.
3) For each parameter updated by a non zero value, the 5-bit hash is used to look up a bit in the 32-bit field and set it to 1.
4) The weights of a feature are saved if at least 10 bits in the bitset are set to 1.
