### PR TITLE
Benchmarks for Privacy Preserving Learning

### DIFF
--- a/test/benchmarks/standalone/benchmark_text_input.cc
+++ b/test/benchmarks/standalone/benchmark_text_input.cc
@@ -51,7 +51,25 @@ static void benchmark_cb_adf_learn(benchmark::State& state, int feature_count)
 {
   auto vw = VW::initialize("--cb_explore_adf --epsilon 0.1 --quiet -q ::", nullptr, false, nullptr, nullptr);
   multi_ex examples;
-  examples.push_back(VW::read_example(*vw, std::string("shared | s_1 s_2")));
+  examples.push_back(VW::read_example(*vw, std::string("shared tag1| s_1 s_2")));
+  examples.push_back(VW::read_example(*vw, get_x_string_fts(feature_count)));
+  examples.push_back(VW::read_example(*vw, get_x_string_fts_no_label(feature_count)));
+  examples.push_back(VW::read_example(*vw, get_x_string_fts_no_label(feature_count)));
+
+  for (auto _ : state)
+  {
+    vw->learn(examples);
+    benchmark::ClobberMemory();
+  }
+  vw->finish_example(examples);
+  VW::finish(*vw);
+}
+
+static void benchmark_cb_adf_learn_privacy_preserving(benchmark::State& state, int feature_count)
+{
+  auto vw = VW::initialize("--privacy_activation --cb_explore_adf --epsilon 0.1 --quiet -q ::", nullptr, false, nullptr, nullptr);
+  multi_ex examples;
+  examples.push_back(VW::read_example(*vw, std::string("shared tag1| s_1 s_2")));
   examples.push_back(VW::read_example(*vw, get_x_string_fts(feature_count)));
   examples.push_back(VW::read_example(*vw, get_x_string_fts_no_label(feature_count)));
   examples.push_back(VW::read_example(*vw, get_x_string_fts_no_label(feature_count)));
@@ -224,6 +242,9 @@ BENCHMARK_CAPTURE(benchmark_ccb_adf_learn, many_features, "a b c d e f g h i j k
 
 BENCHMARK_CAPTURE(benchmark_cb_adf_learn, few_features, 2);
 BENCHMARK_CAPTURE(benchmark_cb_adf_learn, many_features, 120);
+
+BENCHMARK_CAPTURE(benchmark_cb_adf_learn_privacy_preserving, few_features, 2);
+BENCHMARK_CAPTURE(benchmark_cb_adf_learn_privacy_preserving, many_features, 120);
 
 BENCHMARK_CAPTURE(benchmark_multi, cb_adf_no_namespaces, gen_cb_examples(100, 7, 3, 6, 1, 4, 14, 2, false),
     "--cb_explore_adf --quiet");


### PR DESCRIPTION
Updated benchmark_text_input.cc to add a benchmark test for cb_adf privacy preserving learning